### PR TITLE
Remove a dangling ReactMethod declaration

### DIFF
--- a/android/src/main/java/com/terrareact/TerraReactModule.java
+++ b/android/src/main/java/com/terrareact/TerraReactModule.java
@@ -417,11 +417,6 @@ public class TerraReactModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void checkAuth(String connection, Promise promise){
-        promise.reject("Unimplemented function for Android");
-    }
-
-    @ReactMethod
     public void readGlucoseData(Promise promise){
         if (this.terra == null){
             WritableMap map = new WritableNativeMap();


### PR DESCRIPTION
Fixes #17 

Error:
```
Error: Exception in HostObject::get for prop 'TerraReact': 
com.facebook.react.internal.turbomodule.core.TurboModuleInteropUtils$ParsingException: 
Unable to parse @ReactMethod annotations from native module: TerraReact. 
Details: Module exports two methods to JavaScript with the same name: "checkAuth"
```


The same source code file `android/src/main/java/com/terrareact/TerraReactModule.java` already has a legit `checkAuth` declaration. There is no point in having an extra declaration that throws an error "Unimplemented function for Android".

```java
@ReactMethod
    public void checkAuth(String connection, Promise promise){
        promise.reject("Unimplemented function for Android");
    }

@ReactMethod
    public void checkAuth(String connection, String devID, Promise promise){
        WritableMap map = new WritableNativeMap();
        if (this.terra == null){
            map.putBoolean("success", false);
            return;
        }
        if (parseConnection(connection) == null){
            map.putBoolean("success", false);
            promise.resolve(map);
            return;
        }
        this.terra.checkAuth(parseConnection(connection), (success) -> {
            map.putBoolean("success", success);
            promise.resolve(map);
            return Unit.INSTANCE;
        });
    }
```