### PR TITLE
Remove check for null on getData functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ export function getActivity(
         const data: DataMessage = {
           success: d.success,
           data:
-            d.data !== undefined || d.data !== null ? JSON.parse(d.data) : null,
+            d.data !== undefined ? JSON.parse(d.data) : null,
           error: d.error,
         };
         resolve(data);
@@ -329,7 +329,7 @@ export function getDaily(
         const data: DataMessage = {
           success: d.success,
           data:
-            d.data !== undefined || d.data !== null ? JSON.parse(d.data) : null,
+            d.data !== undefined ? JSON.parse(d.data) : null,
           error: d.error,
         };
         resolve(data);
@@ -357,7 +357,7 @@ export function getNutrition(
         const data: DataMessage = {
           success: d.success,
           data:
-            d.data !== undefined || d.data !== null ? JSON.parse(d.data) : null,
+            d.data !== undefined ? JSON.parse(d.data) : null,
           error: d.error,
         };
         resolve(data);


### PR DESCRIPTION
We had an issue with `terra-react` throwing an error when calling `getDaily()`. After a short investigation, we found that 3 of the get data functions do a check for null on the data field of the Terra results.

https://github.com/tryterra/terra-react/blob/f8f9df42019693dc0b6f73646fd6ff2158b4472c/src/index.ts#L328-L336

As this is in a logical OR with the check for undefined, it will resolve to true when the data field is `undefined`. As `undefined` is not a valid JSON value, `JSON.parse` throws an error.

![Screenshot 2024-08-08 at 11 42 35 AM](https://github.com/user-attachments/assets/9d42d619-64e7-4763-b77a-603ee182eccd)

![Screenshot 2024-08-08 at 10 26 37 AM](https://github.com/user-attachments/assets/9fa6184e-9c19-481f-a1a2-c8e42408b97c)

This PR brings `getActivity`, `getDaily`, and `getNutrition` in line with the other get data functions. `null` is a valid JSON value that parses to `null`, making the check for it unnecessary in this instance.

Thanks!