### PR TITLE
feat: simplify expo plugin

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,10 +1,7 @@
 import {
   ConfigPlugin,
   withAppDelegate,
-  withInfoPlist,
-  withAndroidManifest,
   createRunOncePlugin,
-  AndroidConfig,
 } from '@expo/config-plugins';
 
 const withTerraBackgroundDelivery: ConfigPlugin = (config) => {
@@ -30,87 +27,26 @@ const withTerraBackgroundDelivery: ConfigPlugin = (config) => {
             (match) => `Terra.setUpBackgroundDelivery()\n  ${match}`
           );
       }
-      return delegateConfig;
-    }
-
-    if (!contents.includes('#import <TerraiOS/TerraiOS-Swift.h>')) {
-      delegateConfig.modResults.contents = contents.replace(
-        '#import "AppDelegate.h"',
-        '#import "AppDelegate.h"\n#import <TerraiOS/TerraiOS-Swift.h>'
-      );
-    }
-
-    if (!contents.includes('[Terra setUpBackgroundDelivery];')) {
-      const regex =
-        /- \(BOOL\)application:\(UIApplication \*\)application didFinishLaunchingWithOptions:\(NSDictionary \*\)launchOptions\s*\{\n/;
-      delegateConfig.modResults.contents =
-        delegateConfig.modResults.contents.replace(
-          regex,
-          (match) => `${match}  [Terra setUpBackgroundDelivery];\n`
+    } else {
+      if (!contents.includes('#import <TerraiOS/TerraiOS-Swift.h>')) {
+        delegateConfig.modResults.contents = contents.replace(
+          '#import "AppDelegate.h"',
+          '#import "AppDelegate.h"\n#import <TerraiOS/TerraiOS-Swift.h>'
         );
+      }
+
+      if (!contents.includes('[Terra setUpBackgroundDelivery];')) {
+        const regex =
+          /- \(BOOL\)application:\(UIApplication \*\)application didFinishLaunchingWithOptions:\(NSDictionary \*\)launchOptions\s*\{\n/;
+        delegateConfig.modResults.contents =
+          delegateConfig.modResults.contents.replace(
+            regex,
+            (match) => `${match}  [Terra setUpBackgroundDelivery];\n`
+          );
+      }
     }
 
     return delegateConfig;
-  });
-
-  config = withInfoPlist(config, (infoPlistConfig) => {
-    infoPlistConfig.modResults.NSHealthShareUsageDescription =
-      'custom text shown in the Apple Health permission screen';
-    infoPlistConfig.modResults.NSHealthClinicalHealthRecordsShareUsageDescription =
-      'custom text shown in the Apple Health permission screen';
-    infoPlistConfig.modResults.NSHealthUpdateUsageDescription =
-      'custom text shown in the Apple Health permission screen';
-    infoPlistConfig.modResults.BGTaskSchedulerPermittedIdentifiers = [
-      'co.tryterra.data.post.request',
-    ];
-    infoPlistConfig.modResults.UIBackgroundModes = [
-      ...(infoPlistConfig.modResults.UIBackgroundModes || []),
-      'processing',
-      'fetch',
-    ];
-    return infoPlistConfig;
-  });
-
-  config = withAndroidManifest(config, (androidConfig) => {
-    const mainActivity = AndroidConfig.Manifest.getMainActivityOrThrow(
-      androidConfig.modResults
-    );
-
-    if (!mainActivity['intent-filter']) {
-      mainActivity['intent-filter'] = [];
-    }
-
-    const existingActions = mainActivity['intent-filter'].flatMap(
-      (f) => f.action?.map((a) => a.$['android:name']) || []
-    );
-
-    const intentFiltersToAdd = [
-      {
-        action: 'androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE',
-      },
-      {
-        action: 'android.intent.action.VIEW_PERMISSION_USAGE',
-        category: ['android.intent.category.HEALTH_PERMISSIONS'],
-      },
-    ];
-
-    intentFiltersToAdd.forEach((filter) => {
-      if (!existingActions.includes(filter.action)) {
-        const intentFilter: any = {
-          action: [{ $: { 'android:name': filter.action } }],
-        };
-
-        if (filter.category) {
-          intentFilter.category = filter.category.map((cat) => ({
-            $: { 'android:name': cat },
-          }));
-        }
-
-        mainActivity['intent-filter']?.push(intentFilter);
-      }
-    });
-
-    return androidConfig;
   });
 
   return config;


### PR DESCRIPTION
## Summary

The expo config plugin edits:
- AppDelegate
- iOS infoPlist
- AndroidManifest

The problem with the current plugin is that the values for the infoPlist are configurable, as in they do not support passing custom values instead of the dummy:
- custom text shown in the Apple Health permission screen
- custom text shown in the Apple Health permission screen
- custom text shown in the Apple Health permission screen

While we can make the plugin accept arguments and dynamically use those, the better solution is let library users use existing expo tools to configure what already can be configured and only use the config plugin to configure those that can't be.

The change in this pr gets rid of the edits in:
- iOS infoPlist
- AndroidManifest

and only updates the AppDelegate.

The iOS infoPlist and AndroidManifest changes can be implemented by library users through the following config in `app.json`, 'app.config.(js/ts)':


Here is an example with `app.config.(js/ts)`. If you do not need background syncs, then one can remove the related configs
```js
{
    ios: {
      entitlements: {
        'com.apple.developer.healthkit': true,
        'com.apple.developer.healthkit.access': ['health-records'],
        'com.apple.developer.healthkit.background-delivery': true,
      },
      infoPlist: {
        UIBackgroundModes: ['fetch', 'processing'],
        NSHealthShareUsageDescription:
          'This app needs permission to share your health data',
        NSHealthUpdateUsageDescription:
          'This app needs permission to update your health data',
        NSHealthClinicalHealthRecordsShareUsageDescription:
          'This app needs permission to record your health data',
        BGTaskSchedulerPermittedIdentifiers: ['co.tryterra.data.post.request'],
      },
    },
    android: {
      intentFilters: [
        {
          action: 'androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE',
        },
        {
          action: 'android.intent.action.VIEW_PERMISSION_USAGE',
          category: 'android.intent.category.HEALTH_PERMISSIONS',
        },
      ],
    },
  }
```