### PR TITLE
deprecate: mark FreeStyle Libre and planned workout functions as deprecated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -448,6 +448,9 @@ export function postPlannedWorkout(
   });
 }
 
+/**
+ * @deprecated This method is deprecated and will be removed in a future release.
+ */
 export function readGlucoseData(): Promise<Object> {
   return new Promise<Object>((resolve, reject) => {
     TerraReact.readGlucoseData()
@@ -460,6 +463,9 @@ export function readGlucoseData(): Promise<Object> {
   });
 }
 
+/**
+ * @deprecated This method is deprecated and will be removed in a future release.
+ */
 export function activateSensor(): Promise<Object> {
   return new Promise<Object>((resolve, reject) => {
     TerraReact.activateSensor()

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,6 +373,7 @@ export function postActivity(
       });
   });
 }
+/** @deprecated This method is deprecated and will be removed in a future release. */
 export function getPlannedWorkouts<T = any>(
   connection: Connections_
 ): Promise<ListDataMessage<T>> {
@@ -389,6 +390,7 @@ export function getPlannedWorkouts<T = any>(
       .catch((e: Error) => reject(e));
   });
 }
+/** @deprecated This method is deprecated and will be removed in a future release. */
 export function deletePlannedWorkout(
   connection: Connections_,
   id: string
@@ -406,6 +408,7 @@ export function deletePlannedWorkout(
   });
 }
 
+/** @deprecated This method is deprecated and will be removed in a future release. */
 export function completePlannedWorkout(
   connection: Connections_,
   id: string,
@@ -428,6 +431,7 @@ export function completePlannedWorkout(
   });
 }
 
+/** @deprecated This method is deprecated and will be removed in a future release. */
 export function postPlannedWorkout(
   connection: Connections_,
   payload: TerraPlannedWorkout


### PR DESCRIPTION
## Summary

Adds JSDoc `@deprecated` annotations to the following functions in `src/index.ts`:

### FreeStyle Libre
- `readGlucoseData()`
- `activateSensor()`

### Planned Workouts
- `postPlannedWorkout(connection, payload)`
- `getPlannedWorkouts(connection)`
- `deletePlannedWorkout(connection, id)`
- `completePlannedWorkout(connection, id, at?)`

No logic changes — annotation only. IDEs will show deprecation warnings for these functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)