### PR TITLE
[1.9.4] Bump TerraiOS to 1.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 1.9.4
+- Bump TerraiOS SDK to 1.7.7 — planned workout backend sync enabled by default
+
 ## 1.9.3
 - Bump TerraiOS SDK to 1.7.5 (https://github.com/tryterra/TerraiOS/wiki/Change-Log)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.5"
+  s.dependency "TerraiOS", "1.7.7"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
## Summary
- Bump TerraiOS SDK from 1.7.5 to 1.7.7
- Planned workout backend sync is now enabled by default — no RN-side code changes needed