### PR TITLE
Bump android-sdk to 0.0.11 (Samsung permission-cache fix)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     // implementation fileTree(dir: 'libs', include: ['*.aar'])
-    implementation 'co.tryterra:android-sdk:0.0.10'
+    implementation 'co.tryterra:android-sdk:0.0.11'
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bumps `co.tryterra:android-sdk` 0.0.10 → **0.0.11** on the Samsung RN bridge, and the package version to 0.6.4.

0.0.11 (TerraAndroidLocal PR #17) fixes the Samsung-direct SDK returning empty activity/sleep for users whose permissions were already granted — it now resolves the granted-permissions set per read instead of relying on a stale process-global cache. Verified on a Samsung Health emulator (a recorded workout returned empty on the buggy build, populated after the fix).

Once merged + published to npm, customers on the samsung-tagged RN bridge upgrade to pick up the fix.