### PR TITLE
release: terra-react 1.9.6 (latest native SDKs)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'co.tryterra:terra-android:1.6.3'
+    implementation 'co.tryterra:terra-android:1.7.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1'
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.8"
+  s.dependency "TerraiOS", "1.7.9"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
Bumps to **1.9.6** and pins the latest native SDKs: **TerraiOS 1.7.9** (CocoaPods) and **co.tryterra:terra-android 1.7.1** (Maven Central).

After merge, the npm publish runs via `release_package.yml` (workflow_dispatch / release, uses `NPMJS_ACCESS_TOKEN`). `master` requires 1 approving review.