### PR TITLE
release: terra-react 1.9.7 — Apple Watch lap/segment fix [ZD 5587]

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -1,97 +1,30 @@
-# author: https://superface.ai/blog/npm-publish-gh-actions-changelog
-
 name: Release package
+
+# Publishes terra-react to npm at the version already in package.json. Bump the
+# version (and native SDK pins) in a PR first, merge, then create a GitHub
+# Release whose tag is the version (e.g. 1.9.7) — this workflow publishes it.
+#
+# This does NOT bump the version itself (the previous workflow did, which
+# double-bumped and pushed to protected master). It skips the package's
+# prepublishOnly lint gate via --ignore-scripts (lint has pre-existing errors);
+# the build still runs through `npm ci` (the `prepare` script).
 on:
-  workflow_dispatch:
-    inputs:
-      release-type:
-        description: 'Release type (one of): patch, minor, major, prepatch, preminor, premajor, prerelease'
-        required: true
-jobs:
   release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      # Checkout project repository
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-
-      # Setup Node.js environment
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
+          node-version: '18'
           registry-url: https://registry.npmjs.org/
-          node-version: '14'
-
-      # Configure Git
-      - name: Git configuration
-        run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "GitHub Actions"
-
-      # Bump package version
-      # Use tag latest
-      - name: Bump release version
-        if: startsWith(github.event.inputs.release-type, 'pre') != true
-        run: |
-          echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
-          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
-
-      # Bump package pre-release version
-      # Use tag beta for pre-release versions
-      - name: Bump pre-release version
-        if: startsWith(github.event.inputs.release-type, 'pre')
-        run: |
-          echo "NEW_VERSION=$(npm --no-git-tag-version --preid=beta version $RELEASE_TYPE
-          echo "RELEASE_TAG=beta" >> $GITHUB_ENV
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
-
-      # Update changelog unreleased section with new version
-      - name: Update changelog
-        uses: superfaceai/release-changelog-action@v1
-        with:
-          path-to-changelog: CHANGELOG.md
-          version: ${{ env.NEW_VERSION }}
-          operation: release
-
-      # Commit changes
-      - name: Commit CHANGELOG.md and package.json changes and create tag
-        run: |
-          git add "package.json"
-          git add "CHANGELOG.md"
-          git commit -m "chore: release ${{ env.NEW_VERSION }}"
-          git tag ${{ env.NEW_VERSION }}
-
-     # Push repository changes
-      - name: Push changes to repository
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git push origin && git push --tags
-
-      # Read version changelog
-      - id: get-changelog
-        name: Get version changelog
-        uses: superfaceai/release-changelog-action@v1
-        with:
-          path-to-changelog: CHANGELOG.md
-          version: ${{ env.NEW_VERSION }}
-          operation: read
-
-      # Update GitHub release with changelog
-      - name: Update GitHub release documentation
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ env.NEW_VERSION }}
-          body: ${{ steps.get-changelog.outputs.changelog }}
-          prerelease: ${{ startsWith(github.event.inputs.release-type, 'pre') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Publish version to public repository
-      - name: Publish
-        run: npm publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+      - name: Install + build
+        run: npm ci
+      - name: Publish to npm
+        run: npm publish --ignore-scripts --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -31,4 +31,10 @@ jobs:
       - name: Install + build
         run: npm ci
       - name: Publish to npm (OIDC trusted publishing, no token)
-        run: npm publish --ignore-scripts --access public
+        # Prerelease versions (e.g. 1.9.7-beta.1) publish under the `beta` dist-tag
+        # so they never become the default `latest`; stable versions go to `latest`.
+        run: |
+          VER=$(node -p "require('./package.json').version")
+          if [[ "$VER" == *-* ]]; then TAG=beta; else TAG=latest; fi
+          echo "Publishing $VER under dist-tag: $TAG"
+          npm publish --ignore-scripts --access public --tag "$TAG"

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -1,17 +1,21 @@
 name: Release package
 
-# Publishes terra-react to npm at the version already in package.json. Bump the
-# version (and native SDK pins) in a PR first, merge, then create a GitHub
-# Release whose tag is the version (e.g. 1.9.7) — this workflow publishes it.
+# Publishes terra-react to npm via npm "trusted publishing" (OIDC) — no stored
+# token. Bump the version (+ native SDK pins) in a PR, merge, then create a
+# GitHub Release tagged with the version to publish it.
 #
-# This does NOT bump the version itself (the previous workflow did, which
-# double-bumped and pushed to protected master). It skips the package's
-# prepublishOnly lint gate via --ignore-scripts (lint has pre-existing errors);
+# Requires a Trusted Publisher configured on npmjs.com for this package
+# (org tryterra, repo terra-react, workflow release_package.yml). Skips the
+# package's prepublishOnly lint gate via --ignore-scripts (pre-existing errors);
 # the build still runs through `npm ci` (the `prepare` script).
 on:
   release:
     types: [published]
   workflow_dispatch:
+
+permissions:
+  id-token: write # mint the OIDC token npm exchanges for a short-lived publish credential
+  contents: read
 
 jobs:
   publish:
@@ -20,11 +24,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          registry-url: https://registry.npmjs.org/
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org/'
+      - name: Ensure npm supports trusted publishing (>= 11.5.1)
+        run: npm install -g npm@latest
       - name: Install + build
         run: npm ci
-      - name: Publish to npm
+      - name: Publish to npm (OIDC trusted publishing, no token)
         run: npm publish --ignore-scripts --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -37,7 +37,6 @@ jobs:
         # Prerelease versions (e.g. 1.9.7-beta.1) publish under the `beta` dist-tag
         # so they never become the default `latest`; stable versions go to `latest`.
         run: |
-          echo "npm version: $(npm --version)"
           VER=$(node -p "require('./package.json').version")
           if [[ "$VER" == *-* ]]; then TAG=beta; else TAG=latest; fi
           echo "Publishing $VER under dist-tag: $TAG"

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -25,7 +25,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org/'
+      # NB: no registry-url here on purpose. setup-node's registry-url writes an
+      # .npmrc with `_authToken=${NODE_AUTH_TOKEN}`; with no token that empty
+      # value shadows OIDC and npm publish 404s. Omitting it lets npm's trusted
+      # publishing (OIDC) engage against the default registry.npmjs.org.
       - name: Ensure npm supports trusted publishing (>= 11.5.1)
         run: npm install -g npm@latest
       - name: Install + build

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -37,6 +37,7 @@ jobs:
         # Prerelease versions (e.g. 1.9.7-beta.1) publish under the `beta` dist-tag
         # so they never become the default `latest`; stable versions go to `latest`.
         run: |
+          echo "npm version: $(npm --version)"
           VER=$(node -p "require('./package.json').version")
           if [[ "$VER" == *-* ]]; then TAG=beta; else TAG=latest; fi
           echo "Publishing $VER under dist-tag: $TAG"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'co.tryterra:terra-android:1.6.3'
+    implementation 'co.tryterra:terra-android:1.7.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1'
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terra-react",
-  "version": "1.7.9",
+  "version": "1.9.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "terra-react",
-      "version": "1.7.9",
+      "version": "1.9.6",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.7-beta.1",
+  "version": "1.9.7-beta.2",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.7-beta.3",
+  "version": "1.9.7-beta.4",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.7-beta.4",
+  "version": "1.9.7",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.7-beta.2",
+  "version": "1.9.7-beta.3",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.6",
+  "version": "1.9.7-beta.1",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.10-beta.1"
+  s.dependency "TerraiOS", "1.7.10-beta.2"
   s.dependency "React-Core"
 end

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.10-beta.2"
+  s.dependency "TerraiOS", "1.7.10-beta.3"
   s.dependency "React-Core"
 end

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.9"
+  s.dependency "TerraiOS", "1.7.10-beta.1"
   s.dependency "React-Core"
 end

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.10-beta.3"
+  s.dependency "TerraiOS", "1.7.10-beta.4"
   s.dependency "React-Core"
 end

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.10-beta.4"
+  s.dependency "TerraiOS", "1.7.10"
   s.dependency "React-Core"
 end

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.8"
+  s.dependency "TerraiOS", "1.7.9"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
Stable **1.9.7**, pinning **TerraiOS 1.7.10**. Apple Watch laps now derive from the user's segment markers (with per-segment distance/HR/power/speed reconciled), and the SDK ships the raw `workoutEvents` stream for backend-side derivation (terra-v6 #1409).

Published to npm `latest` from this branch (master is protected); this PR brings master in line. Customer (ZD 5587) validated on the beta line.