### PR TITLE
Bump android-sdk to 0.0.12 (crash fix: Samsung Health not installed)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     // implementation fileTree(dir: 'libs', include: ['*.aar'])
-    implementation 'co.tryterra:android-sdk:0.0.11'
+    implementation 'co.tryterra:android-sdk:0.0.12'
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bumps `co.tryterra:android-sdk` 0.0.11 → **0.0.12** (package → `0.6.5`).

0.0.12 (TerraAndroidLocal PR #26) fixes a crash on init introduced in 0.0.11: for users linked to Samsung Health without the Samsung Health app installed, the per-sync permission check threw an uncaught `ResolvablePlatformException`. It now fails safe (no data instead of a crash).