### PR TITLE
CI: publish the Samsung line via OIDC under samsung-custom

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -1,17 +1,27 @@
 name: Release package
 
 # Publishes terra-react to npm via npm "trusted publishing" (OIDC) — no stored
-# token. Bump the version (+ native SDK pins) in a PR, merge, then create a
-# GitHub Release tagged with the version to publish it.
+# token. Standard line: create a GitHub Release (publishes to `latest`).
+# Samsung line: workflow_dispatch with ref=android-samsung-sdk and
+# dist-tag=samsung-custom (publishes that branch's version under the
+# `samsung-custom` dist-tag, leaving `latest` untouched).
 #
-# Requires a Trusted Publisher configured on npmjs.com for this package
-# (org tryterra, repo terra-react, workflow release_package.yml). Skips the
-# package's prepublishOnly lint gate via --ignore-scripts (pre-existing errors);
-# the build still runs through `npm ci` (the `prepare` script).
+# Requires a Trusted Publisher on npmjs.com: org tryterra, repo terra-react,
+# workflow release_package.yml. Skips the prepublishOnly lint gate via
+# --ignore-scripts; the build still runs via `npm ci` (the `prepare` script).
 on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch/tag to publish (blank = this ref). Samsung line: android-samsung-sdk'
+        required: false
+        default: ''
+      dist-tag:
+        description: 'npm dist-tag: latest (standard) or samsung-custom (Samsung line)'
+        required: false
+        default: 'latest'
 
 permissions:
   id-token: write # mint the OIDC token npm exchanges for a short-lived publish credential
@@ -22,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -31,4 +43,4 @@ jobs:
       - name: Install + build
         run: npm ci
       - name: Publish to npm (OIDC trusted publishing, no token)
-        run: npm publish --ignore-scripts --access public
+        run: npm publish --ignore-scripts --access public --tag ${{ github.event.inputs.dist-tag || 'latest' }}


### PR DESCRIPTION
Extends the existing OIDC trusted-publishing workflow so it can publish the **Samsung line** too, reusing the same trusted publisher (no token, no new npm config).

- `workflow_dispatch` gains `ref` (checkout, e.g. `android-samsung-sdk`) and `dist-tag` (e.g. `samsung-custom`).
- Publish runs `npm publish --tag <dist-tag>` — Samsung versions go under `samsung-custom`, leaving standard `latest` untouched.
- Standard GitHub-Release publishing is unchanged (empty inputs → `latest`).

Usage for the Samsung line: `gh workflow run release_package.yml --ref master -f ref=android-samsung-sdk -f dist-tag=samsung-custom`.