### PR TITLE
fix(android): bump TerraAndroid SDK to 1.7.2 so Health Connect data syncs again [ZD 5977]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 1.9.10
+- Bump TerraAndroid SDK to 1.7.2 (https://github.com/tryterra/TerraAndroid/wiki/Change-Log) — fixes Android Health Connect data not syncing. Upgrade recommended for all Android users.
+
 ## 1.9.9
 - Port `requestPermissions` argument to react native interface
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'co.tryterra:terra-android:1.7.1'
+    implementation 'co.tryterra:terra-android:1.7.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1'
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terra-react",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "terra-react",
-      "version": "1.9.9",
+      "version": "1.9.10",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
Android Health Connect data delivery has been broken for React Native customers since early July. Users authenticate, `auth_success` fires, connections stay active, and no data ever follows.

## Root cause

`terra-android` 1.7.0 gated the scheduler on the Health Connect Changes API. In `hasChangesSinceLastRun`, a broad Terra scope (e.g. `DAILY`) expands into record types the user may not have granted; the resulting `SecurityException` was caught and treated as "no changes":

```kotlin
} catch (e: SecurityException) {
    Log.e(TAG, "Changes API permission denied for $resource/$permission: ${e.message}")
    return false   // 1.7.1
}
```

`ScheduleMimic` therefore skipped the fetch entirely. The worker completes and reports SUCCESS, which is why this looks like silence rather than an error.

The native fix is `TerraAndroidLocal` #29, released as **terra-android 1.7.2** on Maven Central on 18 July. It returns `true` on that catch (fail-open) and filters record types through the actually-granted set before building the changes token.

**terra-react has never carried it.** 1.9.9 published 15 July, three days before 1.7.2 existed, and `android/build.gradle:59` still pins 1.7.1. There is currently no published terra-react version containing the fix, so affected customers cannot resolve this from their side at any version.

## What this changes

- `android/build.gradle` — pin `co.tryterra:terra-android` 1.7.1 to 1.7.2
- `package.json` / `package-lock.json` — 1.9.9 to 1.9.10
- `CHANGELOG.md` — entry in house style

Version bumped so the release is merge-and-publish; nothing is published by this PR.

## Verification

Verified against the **published artifacts**, not just the source repo:

- `terra-android` 1.7.2 pom, aar and sources jar all resolve 200 from Maven Central; `<release>` is 1.7.2.
- Published 1.7.1 sources: `return false` at `HealthConnect.kt:337`. Published 1.7.2 sources: `return true` at `HealthConnect.kt:341`, plus the new `HCPermissions.permittedRecordTypeSet` filter. The bug and the fix are both confirmed in the shipped binaries.
- The complete published delta between 1.7.1 and 1.7.2 is exactly two files, `HealthConnect.kt` and `HCPermissions.kt`. Nothing else changes.
- The 1.7.1 and 1.7.2 poms are byte-identical apart from the version element, so no transitive dependency or compileSdk movement.
- Bridge safety: `TerraReactModule.java` imports only `Terra`, `TerraManager` and enums. Both changed native members are `internal` and unreachable from the bridge.

**Not verified on device.** I have not run an on-device Health Connect repro, so the end-to-end claim that data resumes after upgrade rests on the native fix being correct, not on my own observation.

## Risk

Additive. Every terra-react Android customer moves from the fail-closed gate to the fail-open one on upgrade. The failure mode of the fix is a redundant read, not a missed one.

## Notes for the reviewer

- **PR #39 is obsolete and should be closed.** It bumps 1.6.3 to 1.7.0, master is already past it at 1.7.1, and it is CONFLICTING.
- **Merge order vs #36.** `antoine/terra-react-android-hc-rationale` branches off the same base, also touches Android Health Connect, and does not bump the version. Whichever merges second either ships silently inside 1.9.10 or needs a re-bump.
- `terra-flutter` pins 1.7.1 at `android/build.gradle:43` and has the identical problem. Separate PR to follow.

Driven by ZD 5977 / 6179.
