### PR TITLE
release: 1.9.11-beta.1 — TerraiOS 1.9.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.10",
+  "version": "1.9.11-beta.1",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.7.11"
+  s.dependency "TerraiOS", "1.9.0-beta.1"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
Version bump only. No functional change in this PR.

Pre-release for Equinox to validate the Apple device-lock fix (TerraiOSPackage #68). Publishes under the `beta` dist-tag, so `latest` stays on `1.9.10`.

## The iOS dependency jumps two releases

```
s.dependency "TerraiOS", "1.7.11"  ->  "1.9.0-beta.1"
```

React Native has been pinned to **1.7.11** throughout, so this is the first time RN picks up anything from 1.8.0 or 1.8.1 — including the HealthKit unit-conversion crash guard (TerraiOSPackage #63, ZD-6150). Worth knowing when reading any behaviour change: it is two iOS releases of delta, not one.

## Cut by hand, not via `bump-terra-react.yml`

That workflow cannot produce this, for three independent reasons:

1. It reads the iOS version with `grep -E -o '([0-9]).([0-9]).([0-9]+)'`, which matches `1.9.0` out of `1.9.0-beta.1` — it would pin a version that **does not exist on trunk** and break installs.
2. It only ever bumps **patch**.
3. Its `npm publish` has no `--tag`, so it would go to `latest`.

Worth fixing separately, or retiring in favour of `release_package.yml`, which already does the right thing.

## Publishing

Not via a GitHub Release — that path publishes to `latest`. Once merged, dispatch `release_package.yml` with:

| input | value |
|---|---|
| `ref` | `release/1.9.11-beta.1` (or the merge commit) |
| `dist-tag` | `beta` |

Matches how `1.9.7-beta.4` sits under `beta` today.

## For Equinox

```
npm install terra-react@1.9.11-beta.1
```

## Blocked on

TerraiOSPackage `1.9.0-beta.1` must be on CocoaPods trunk first, or the pod install will not resolve. That release is staged in TerraiOSPackage #70 and not yet cut.