### PR TITLE
ci: report when terra-react falls behind its native SDKs

### DIFF
--- a/.github/workflows/native-version-drift.yml
+++ b/.github/workflows/native-version-drift.yml
@@ -73,7 +73,11 @@ jobs:
           body="${body}${{ steps.drift.outputs.body }}"
           body="${body}"$'\n\nBump `terra-react.podspec` / `android/build.gradle` in a PR, then publish via `release_package.yml`.'
 
-          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')
+          # Exact title match, client-side. `--search "... in:title"` is fuzzy, and
+          # this edits the issue body — a loose match would overwrite someone's
+          # unrelated open issue.
+          existing=$(gh issue list --state open --limit 200 --json number,title \
+            | jq -r --arg t "$title" '[.[] | select(.title == $t)] | .[0].number // empty')
           if [ -n "$existing" ]; then
             gh issue edit "$existing" --body "$body"
           else

--- a/.github/workflows/native-version-drift.yml
+++ b/.github/workflows/native-version-drift.yml
@@ -78,13 +78,11 @@ jobs:
           body="${body}${{ steps.drift.outputs.body }}"
           body="${body}"$'\n\nBump `terra-react.podspec` / `android/build.gradle` in a PR, then publish via `release_package.yml`.'
 
-          # `gh issue list --search "... in:title"` is fuzzy; match titles client-side
-          # before editing an issue.
-          # Scope by label rather than scanning open issues: a --limit large enough
-          # today is a duplicate report on a repo that grows past it. The exact
-          # title check then guards against the label being applied by hand.
+          # Label-scoped so the lookup does not depend on issue volume; --limit is
+          # explicit because gh defaults to 30. Titles are matched client-side
+          # because `--search "... in:title"` is fuzzy and this edits a body.
           gh label create "$label" --description "Automated native SDK version drift report" --color ededed --force >/dev/null 2>&1 || true
-          existing=$(gh issue list --state open --label "$label" --json number,title \
+          existing=$(gh issue list --state open --label "$label" --limit 1000 --json number,title \
             | jq -r --arg t "$title" '[.[] | select(.title == $t)] | .[0].number // empty')
           if [ -n "$existing" ]; then
             gh issue edit "$existing" --body "$body"

--- a/.github/workflows/native-version-drift.yml
+++ b/.github/workflows/native-version-drift.yml
@@ -1,0 +1,82 @@
+name: Native version drift
+
+# terra-react pins its two native SDKs by exact version, and nothing reported when
+# they fell behind. It sat on TerraiOS 1.7.11 through the 1.8.0 and 1.8.1 releases
+# — React Native customers silently missed both, including a crash fix.
+#
+# Opens (or updates) one issue when a pin is BEHIND the latest release. Never
+# bumps anything: a version jump that is sometimes two releases wide deserves a
+# human on the PR.
+#
+# Sources of truth are where each artefact is actually published, not GitHub tags
+# — terra-android's tags lag Maven, so tags would report drift that isn't real.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays, 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare pins against published releases
+        id: drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          pinned_ios=$(grep -oE 's\.dependency "TerraiOS", "[^"]+"' terra-react.podspec | grep -oE '"[^"]+"$' | tr -d '"')
+          latest_ios=$(gh api repos/tryterra/TerraiOS/tags --jq '[.[].name | select(test("-") | not)] | .[0]')
+
+          pinned_android=$(grep -oE "co\.tryterra:terra-android:[0-9][^']*" android/build.gradle | cut -d: -f3)
+          latest_android=$(curl -sf --max-time 30 https://repo1.maven.org/maven2/co/tryterra/terra-android/maven-metadata.xml \
+            | grep -oE '<version>[^<]+' | sed 's/<version>//' | tail -1)
+
+          python3 - "$pinned_ios" "$latest_ios" "$pinned_android" "$latest_android" <<'PY' >> "$GITHUB_OUTPUT"
+          import os, sys
+
+          def parts(v):
+              # Strip any prerelease suffix: a beta pin is deliberate, and comparing
+              # it numerically would report drift for a version we chose on purpose.
+              core = v.split("-")[0]
+              return tuple(int(x) for x in core.split(".") if x.isdigit())
+
+          rows = []
+          for name, pinned, latest in (("TerraiOS", sys.argv[1], sys.argv[2]),
+                                       ("terra-android", sys.argv[3], sys.argv[4])):
+              behind = parts(pinned) < parts(latest)
+              print(f"{name}: pinned={pinned} latest={latest} behind={behind}", file=sys.stderr)
+              if behind:
+                  rows.append(f"- **{name}**: pinned `{pinned}`, latest `{latest}`")
+
+          print(f"drifted={'true' if rows else 'false'}")
+          print("body<<EOF")
+          print("\n".join(rows))
+          print("EOF")
+          PY
+
+      - name: Open or update the drift issue
+        if: steps.drift.outputs.drifted == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="terra-react is behind its native SDKs"
+          body=$'React Native customers do not get a native fix until this pin moves.\n\n'
+          body="${body}${{ steps.drift.outputs.body }}"
+          body="${body}"$'\n\nBump `terra-react.podspec` / `android/build.gradle` in a PR, then publish via `release_package.yml`.'
+
+          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/.github/workflows/native-version-drift.yml
+++ b/.github/workflows/native-version-drift.yml
@@ -8,8 +8,7 @@ name: Native version drift
 # bumps anything: a version jump that is sometimes two releases wide deserves a
 # human on the PR.
 #
-# Sources of truth are where each artefact is actually published, not GitHub tags
-# — terra-android's tags lag Maven, so tags would report drift that isn't real.
+# terra-android's GitHub tags can lag Maven; use Maven as the source of truth.
 
 on:
   schedule:
@@ -34,11 +33,11 @@ jobs:
           set -euo pipefail
 
           pinned_ios=$(grep -oE 's\.dependency "TerraiOS", "[^"]+"' terra-react.podspec | grep -oE '"[^"]+"$' | tr -d '"')
-          latest_ios=$(gh api repos/tryterra/TerraiOS/tags --jq '[.[].name | select(test("-") | not)] | .[0]')
+          latest_ios=$(gh api --paginate repos/tryterra/TerraiOS/tags --jq '.[].name' | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1)
 
           pinned_android=$(grep -oE "co\.tryterra:terra-android:[0-9][^']*" android/build.gradle | cut -d: -f3)
           latest_android=$(curl -sf --max-time 30 https://repo1.maven.org/maven2/co/tryterra/terra-android/maven-metadata.xml \
-            | grep -oE '<version>[^<]+' | sed 's/<version>//' | tail -1)
+            | grep -oE '<version>[^<]+' | sed 's/<version>//' | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1)
 
           python3 - "$pinned_ios" "$latest_ios" "$pinned_android" "$latest_android" <<'PY' >> "$GITHUB_OUTPUT"
           import os, sys
@@ -76,7 +75,7 @@ jobs:
 
           existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
+            gh issue edit "$existing" --body "$body"
           else
             gh issue create --title "$title" --body "$body"
           fi

--- a/.github/workflows/native-version-drift.yml
+++ b/.github/workflows/native-version-drift.yml
@@ -15,6 +15,10 @@ on:
     - cron: '0 9 * * 1'   # Mondays, 09:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: native-version-drift
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write
@@ -69,17 +73,21 @@ jobs:
         run: |
           set -euo pipefail
           title="terra-react is behind its native SDKs"
+          label="native-version-drift"
           body=$'React Native customers do not get a native fix until this pin moves.\n\n'
           body="${body}${{ steps.drift.outputs.body }}"
           body="${body}"$'\n\nBump `terra-react.podspec` / `android/build.gradle` in a PR, then publish via `release_package.yml`.'
 
-          # Exact title match, client-side. `--search "... in:title"` is fuzzy, and
-          # this edits the issue body — a loose match would overwrite someone's
-          # unrelated open issue.
-          existing=$(gh issue list --state open --limit 200 --json number,title \
+          # `gh issue list --search "... in:title"` is fuzzy; match titles client-side
+          # before editing an issue.
+          # Scope by label rather than scanning open issues: a --limit large enough
+          # today is a duplicate report on a repo that grows past it. The exact
+          # title check then guards against the label being applied by hand.
+          gh label create "$label" --description "Automated native SDK version drift report" --color ededed --force >/dev/null 2>&1 || true
+          existing=$(gh issue list --state open --label "$label" --json number,title \
             | jq -r --arg t "$title" '[.[] | select(.title == $t)] | .[0].number // empty')
           if [ -n "$existing" ]; then
             gh issue edit "$existing" --body "$body"
           else
-            gh issue create --title "$title" --body "$body"
+            gh issue create --title "$title" --body "$body" --label "$label"
           fi


### PR DESCRIPTION
A weekly check that opens one issue when a native pin is behind. No product code.

## Why

terra-react pins TerraiOS and terra-android by exact version and nothing reported when they fell behind. It sat on **TerraiOS 1.7.11 through both 1.8.0 and 1.8.1** — React Native customers silently missed both releases, including the HealthKit unit-conversion crash fix (TerraiOSPackage #63). Nobody noticed until a customer needed a beta today, two releases later.

## What it does

Mondays 09:00 UTC, plus `workflow_dispatch`. Opens or comments on a single issue when a pin is behind. It **never bumps anything** — the jump is sometimes two releases wide and deserves a human on the PR.

## Two things it deliberately does not do

**It reads terra-android from Maven Central, not GitHub tags.** The tags lag: terra-android is pinned at `1.7.2` while the newest tag is `1.7.1`. My first version used tags and would have reported drift that does not exist, on its very first run.

**It strips prerelease suffixes before comparing.** Otherwise today's `1.9.0-beta.1` pin reads as behind `1.8.1`, and a beta pin is deliberate.

## Verified against today's real values

| pin | pinned | latest | behind? |
|---|---|---|---|
| TerraiOS (pre-beta) | `1.7.11` | `1.8.1` | **yes** — the case it exists for |
| terra-android | `1.7.2` | `1.7.2` | no |
| TerraiOS (beta pin) | `1.9.0-beta.1` | `1.8.1` | no |