### PR TITLE
release: 1.9.11 — TerraiOS 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.11-beta.1",
+  "version": "1.9.11",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.9.0-beta.1"
+  s.dependency "TerraiOS", "1.9.0"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
Version bump only. No functional change.

Promotes `1.9.11-beta.1`, repinned from the iOS beta to stable `1.9.0`.

## The iOS dependency jumps two releases

```
s.dependency "TerraiOS", "1.7.11"  ->  "1.9.0"
```

React Native was pinned to **1.7.11** throughout, so this is the first RN release carrying anything from 1.8.0 or 1.8.1 — including the HealthKit unit-conversion crash guard (TerraiOSPackage #63, ZD-6150). If anything behaves unexpectedly, the surface is two iOS releases wide, not one.

## What ships

- HealthKit is not read while the device is locked; those reads are deferred and retried on unlock
- Requests report delivery truthfully — previously every call returned success unconditionally, even when the push was rejected
- An unmeasured metric is omitted rather than sent as zero
- Long backfills stop at the first failed week rather than advancing past it

## Publishing

**Not** via a GitHub Release from this branch alone — that path defaults to `latest`, which is correct here, but the merge must land first so master carries `1.9.11`.

After merge, dispatch `release_package.yml` with `ref: master` and `dist-tag: latest`.

## Order

TerraiOSPackage `1.9.0` must be on CocoaPods trunk before this publishes, or `pod install` will not resolve. That release is staged in TerraiOSPackage #75.