### PR TITLE
release: 1.9.12 — terra-android 1.7.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'co.tryterra:terra-android:1.7.2'
+    implementation 'co.tryterra:terra-android:1.7.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1'
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
Bumps the Android pin from `1.7.2` to `1.7.3` (live on Maven Central since today) and the package version to `1.9.12`.

Picks up TerraAndroidLocal#40: when a Health Connect connection is set up with the scheduler on but the user denies `READ_HEALTH_DATA_IN_BACKGROUND`, the SDK used to enqueue the periodic sync worker anyway, where it silently no-opped on every tick. It now skips the periodic worker, still runs one initial sync at connect time, and exposes `isBackgroundDeliveryAvailable()` / `enableBackgroundDelivery()` so hosts can detect and recover.

Two files, matching the convention of #49 (that one bumped `package.json` + `terra-react.podspec` for iOS; this is the Android equivalent, so `package.json` + `android/build.gradle`).

Merge then cut a GitHub Release to trigger `release_package.yml`, which publishes to npm via trusted publishing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tryterra/codesmith/terra-react/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789048599&installation_model_id=431345&pr_number=50&repository=tryterra%2Fterra-react&return_to=https%3A%2F%2Fgithub.com%2Ftryterra%2Fterra-react%2Fpull%2F50&signature=14c77fe793eede374da430beb26fbdefdfb40972518bcbe01524a3f2862cc87c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->