### PR TITLE
release: 0.7.0 (samsung-custom) — TerraiOS 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 0.7.0
+
+### Changed
+- Updated to TerraiOS 1.9.2, from 1.7.5. This is a larger native iOS jump than usual; the
+  notes below cover everything in between. The Samsung Android SDK is unchanged.
+
+### Added
+- Health observation data type — raw HealthKit sample push.
+
+### Fixed
+- Daily totals for samples that span midnight. A step, distance or floor sample that began
+  before midnight and ended after it was split across both days, so neither day reported it
+  in full. It is now counted whole in the day it started. **Daily totals for affected days
+  will increase.**
+- Days where another app writes a whole-day summary. A single HealthKit sample covering the
+  entire day suppressed the individual samples recorded around it — a day of detail could
+  arrive as one entry whose value exceeded the day's own total. Detailed samples are now
+  kept and the roll-up discarded. **`floors_climbed_samples` detail changes as a result.**
+- A single change in HealthKit could produce many identical payloads. Repeats are now
+  suppressed.
+- SDK initialisation no longer stalls if a HealthKit callback is dropped, successful
+  initialisation callbacks are no longer lost, and HealthKit authorisation failures are
+  returned to the caller instead of being swallowed.
+- HealthKit is no longer read while the device is locked.
+- Workouts: per-lap event type and measurement system, stricter swim bounds, and lap end
+  timestamps are now included.
+- Background activity pushes no longer include sources the user has excluded.
+- A crash in HealthKit unit conversion that could not be caught by the host app.
+- Corrected iOS 14.0 availability for six symptom types.
+- Relaxed the wrist-temperature query so readings are no longer missed.
+
+### Upgrade note
+- **Planned workout backend sync is now enabled by default.** If you do not use planned
+  workouts, no action is needed; if you were relying on it being off, set it explicitly.
+
 ## 0.6.6
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "=1.7.5"
+  s.dependency "TerraiOS", "1.9.2"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
Moves the iOS pin from `=1.7.5` to `1.9.2` and bumps the package to 0.7.0. The Samsung Android SDK pin (`co.tryterra:android-sdk:0.0.13`) is unchanged.

**Compatibility:** no public API signature changes in `Terra.swift` or `TerraManager.swift` across 1.7.5 → 1.9.2, and every enum change is additive (`HEALTH_OBSERVATION`). The bridge compiles unchanged — the risk is behavioural, not structural.

⚠️ **Planned workout backend sync became on-by-default in TerraiOS 1.8.0**, which this line has not carried before. Called out in the changelog.

**Do not publish until `TerraiOS 1.9.2` resolves on CocoaPods** — publishing before it lands would break `pod install` for anyone on this line. The 1.9.2 release is cut and building.

Full customer-facing notes in CHANGELOG.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tryterra/codesmith/terra-react/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789758864&installation_model_id=431345&pr_number=54&repository=tryterra%2Fterra-react&return_to=https%3A%2F%2Fgithub.com%2Ftryterra%2Fterra-react%2Fpull%2F54&signature=a241c0b9a061c338d0a95712ae6e1a27603dd750d8069538c745ad2c0150ef58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->