### PR TITLE
[1.9.13] Bump TerraiOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## 1.9.13
-- Bump TerraiOS SDK to 1.9.2 (from 1.9.0). Android SDK unchanged.
-- **Daily totals for samples that span midnight.** A step, distance or floor sample that
-  began before midnight and ended after it was previously split across both days, so
-  neither day reported it in full. It is now counted whole in the day it started. Daily
-  totals for affected days will increase.
-- **Days where another app writes a whole-day summary.** If another HealthKit source wrote
-  a single sample covering the entire day, that sample suppressed the individual samples
-  recorded around it — a day of detail could arrive as one entry whose value exceeded the
-  day's own total. Detailed samples are now kept and the roll-up discarded.
-  `floors_climbed_samples` detail changes as a result.
-- A single change in HealthKit could produce many identical payloads. Repeats are now
-  suppressed.
-- SDK initialisation no longer stalls if a HealthKit callback is dropped, successful
-  initialisation callbacks are no longer lost, and HealthKit authorisation failures are
-  returned to the caller instead of being swallowed.
+- Bump TerraiOS SDK to 1.9.2 (https://github.com/tryterra/TerraiOS/wiki/Change-Log) — daily totals now count a sample spanning midnight in full, in the day it started. Totals for affected days will increase.
+- A whole-day summary written by another HealthKit source no longer suppresses the individual samples recorded around it. `floors_climbed_samples` detail changes as a result.
+- A single change in HealthKit no longer produces repeated identical payloads.
+- HealthKit authorisation failures are returned to the caller instead of being swallowed, and a dropped callback no longer stalls SDK initialisation.
 
 ## 1.9.10
 - Bump TerraAndroid SDK to 1.7.2 (https://github.com/tryterra/TerraAndroid/wiki/Change-Log) — fixes Android Health Connect data not syncing. Upgrade recommended for all Android users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 1.10.0
+- Bump TerraiOS SDK to 1.9.2 (from 1.9.0). Android SDK unchanged.
+- **Daily totals for samples that span midnight.** A step, distance or floor sample that
+  began before midnight and ended after it was previously split across both days, so
+  neither day reported it in full. It is now counted whole in the day it started. Daily
+  totals for affected days will increase.
+- **Days where another app writes a whole-day summary.** If another HealthKit source wrote
+  a single sample covering the entire day, that sample suppressed the individual samples
+  recorded around it — a day of detail could arrive as one entry whose value exceeded the
+  day's own total. Detailed samples are now kept and the roll-up discarded.
+  `floors_climbed_samples` detail changes as a result.
+- A single change in HealthKit could produce many identical payloads. Repeats are now
+  suppressed.
+- SDK initialisation no longer stalls if a HealthKit callback is dropped, successful
+  initialisation callbacks are no longer lost, and HealthKit authorisation failures are
+  returned to the caller instead of being swallowed.
+
 ## 1.9.10
 - Bump TerraAndroid SDK to 1.7.2 (https://github.com/tryterra/TerraAndroid/wiki/Change-Log) — fixes Android Health Connect data not syncing. Upgrade recommended for all Android users.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## 1.10.0
+## 1.9.13
 - Bump TerraiOS SDK to 1.9.2 (from 1.9.0). Android SDK unchanged.
 - **Daily totals for samples that span midnight.** A step, distance or floor sample that
   began before midnight and ended after it was previously split across both days, so

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.9.12",
+  "version": "1.10.0",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-react",
-  "version": "1.10.0",
+  "version": "1.9.13",
   "description": "React Native SDK mapping for Terra API",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/terra-react.podspec
+++ b/terra-react.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.frameworks = ['HealthKit']
-  s.dependency "TerraiOS", "1.9.0"
+  s.dependency "TerraiOS", "1.9.2"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
Bumps the TerraiOS pin from 1.9.0 to 1.9.2. Android SDK unchanged.

- Daily totals now count a sample spanning midnight in full, in the day it started. Totals for affected days will increase.
- A whole-day summary written by another HealthKit source no longer suppresses the individual samples recorded around it. `floors_climbed_samples` detail changes as a result.
- A single change in HealthKit no longer produces repeated identical payloads.
- HealthKit authorisation failures are returned to the caller instead of being swallowed, and a dropped callback no longer stalls SDK initialisation.

TerraiOS 1.9.2 is live on CocoaPods.

Note: #51 also claims 1.9.13 — whichever merges second needs renumbering to 1.9.14.